### PR TITLE
meta content-language english, serbian, Czche and Croatian

### DIFF
--- a/hugo/layouts/partials/head/default.html
+++ b/hugo/layouts/partials/head/default.html
@@ -1,6 +1,7 @@
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="content-language" content="en, sr, cs, hr" />
 
   {{ $title := delimit (slice .Title "&middot;" .Site.Title) " " }}
   <title>{{ $title }}</title>


### PR DESCRIPTION
Based In: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Language
this code will indicate that the website supports more than one language