### PR TITLE
Fix establishment year in nav: EST. 2024 → EST. 2015

### DIFF
--- a/liberland-limited/src/nav.jsx
+++ b/liberland-limited/src/nav.jsx
@@ -47,7 +47,7 @@ function Nav() {
             <div style={{ fontFamily: "var(--serif)", fontSize: 18, fontWeight: 400, letterSpacing: "0.01em", color: "var(--ink)" }}>
               Liberland Limited
             </div>
-            <div className="label" style={{ fontSize: 9.5, marginTop: 4 }}>HONG KONG · EST. 2024</div>
+            <div className="label" style={{ fontSize: 9.5, marginTop: 4 }}>HONG KONG · EST. 2015</div>
           </div>
         </a>
 


### PR DESCRIPTION
## Summary

Updates the nav tagline from `HONG KONG · EST. 2024` to `HONG KONG · EST. 2015` in `liberland-limited/src/nav.jsx`. Per the design handoff at [api.anthropic.com/v1/design/h/UwDnzMOLwHuHTuQvkufIVw](https://api.anthropic.com/v1/design/h/UwDnzMOLwHuHTuQvkufIVw).

Liberland was established in 2015, not 2024.

## Test plan

- [ ] Visit the deployed site, check the nav header reads "HONG KONG · EST. 2015"

https://claude.ai/code/session_01SiLMnJsBPSFsK9mWkHA2mw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiLMnJsBPSFsK9mWkHA2mw)_