### PR TITLE
SEO: surface liberlandlimited.com in search

### DIFF
--- a/liberland-limited/CNAME
+++ b/liberland-limited/CNAME
@@ -1,0 +1,1 @@
+liberlandlimited.com

--- a/liberland-limited/index.html
+++ b/liberland-limited/index.html
@@ -7,6 +7,36 @@
 <meta name="description" content="Liberland Limited is a Hong Kong company offering membership services, hosting community gatherings, and brokering residences at Ark Village on the Danube.">
 <link rel="icon" href="assets/liberland-limited-logo.png">
 
+<!-- Canonical: tells search engines this is the authoritative URL for this content -->
+<link rel="canonical" href="https://liberlandlimited.com/">
+<meta name="robots" content="index, follow, max-image-preview:large">
+
+<!-- Open Graph -->
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Liberland Limited">
+<meta property="og:url" content="https://liberlandlimited.com/">
+<meta property="og:title" content="Liberland Limited — Members. Gatherings. A place on the Danube.">
+<meta property="og:description" content="Liberland Limited is a Hong Kong company offering membership services, hosting community gatherings, and brokering residences at Ark Village on the Danube.">
+<meta property="og:image" content="https://liberlandlimited.com/assets/liberland-limited-logo.png">
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Liberland Limited — Members. Gatherings. A place on the Danube.">
+<meta name="twitter:description" content="Liberland Limited is a Hong Kong company offering membership services, hosting community gatherings, and brokering residences at Ark Village on the Danube.">
+<meta name="twitter:image" content="https://liberlandlimited.com/assets/liberland-limited-logo.png">
+
+<!-- Structured data: helps Google associate the brand name with this domain -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "Liberland Limited",
+  "url": "https://liberlandlimited.com/",
+  "logo": "https://liberlandlimited.com/assets/liberland-limited-logo.png",
+  "description": "Liberland Limited is a Hong Kong company offering membership services, hosting community gatherings, and brokering residences at Ark Village on the Danube."
+}
+</script>
+
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200..700;1,6..72,300..600&family=Geist:wght@300..700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/liberland-limited/robots.txt
+++ b/liberland-limited/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://liberlandlimited.com/sitemap.xml

--- a/liberland-limited/sitemap.xml
+++ b/liberland-limited/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://liberlandlimited.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Problem

Searching "Liberland Limited" surfaces `liberlandlimited.ll.land` — a separate, abandoned **placeholder** site (its snippet is template boilerplate: *"This part will introduce you or your business…"*) — instead of the real site `liberlandlimited.com` built from this repo.

The repo had **no SEO infrastructure**: no canonical tag, no Open Graph, no `robots.txt`, no `sitemap.xml`, no structured data. That makes it hard for Google to index and rank `.com` for its own brand name.

## Changes (`liberland-limited/`)

- **`index.html`** — added `<link rel="canonical">`, `robots` meta, Open Graph + Twitter Card tags, and `Organization` JSON-LD, all pointing at `https://liberlandlimited.com/`.
- **`robots.txt`** — allow all crawlers, reference the sitemap.
- **`sitemap.xml`** — list the homepage.

## What this does NOT do

A repo change can't delete the `.ll.land` result. To actually win the search:

1. **Submit `liberlandlimited.com` to [Google Search Console](https://search.google.com/search-console)** and request indexing of the homepage + sitemap. This is the highest-impact step.
2. **Take down or 301-redirect the `liberlandlimited.ll.land` placeholder** to `.com` (done on whatever hosts that subdomain — not this repo). Removing the duplicate is what stops it from competing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1p77wvhQi1LtzBist6BJE

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1p77wvhQi1LtzBist6BJE)_